### PR TITLE
feat: add Dockerfile for docker deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,40 @@
+# Include any files or directories that you don't want to be copied to your
+# container here (e.g., local build artifacts, temporary files, etc.).
+#
+# For more help, visit the .dockerignore file reference guide at
+# https://docs.docker.com/go/build-context-dockerignore/
+
+.DS_Store
+*.swp
+*.swo
+*~
+.idea/
+.vscode/
+.git/
+.gitignore
+log/*
+tmp/*
+!/log/.keep
+!/tmp/.keep
+spec/
+coverage/
+*.sqlite3
+*.sqlite3-*
+db/*.sqlite3
+.env
+.env.local
+.env.*.local
+node_modules/
+vendor/bundle/
+README.Docker.md
+README.md
+LICENSE.txt
+docker-compose.yml
+docker-compose.*.yml
+.ruby-version
+.rubocop.yml
+.rspec
+.tool-versions
+/public/assets
+/public/packs
+/public/system

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM ruby:3.2.0-slim-bullseye
+
+WORKDIR /app
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    curl \
+    build-essential \
+    && curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY Gemfile Gemfile.lock ./
+RUN bundle install --jobs=$(nproc)
+
+COPY . .
+
+EXPOSE 3000
+CMD ["rails", "server", "-b", "0.0.0.0"]

--- a/README.Docker.md
+++ b/README.Docker.md
@@ -1,0 +1,11 @@
+### Building and running your application
+
+When you're ready, start your application by running:
+
+```bash
+docker build -t pumi_app:1.0 .
+docker run -p 3000:3000 pumi_app:1.0
+```
+
+Consult Docker's [getting started](https://docs.docker.com/go/get-started-sharing/)
+docs for more detail.


### PR DESCRIPTION
This PR adds a basic Dockerfile to support running the app in a containerized environment.

Also included:
- `.dockerignore` to reduce image size
- `README.Docker.md` with simple build and run instructions

This help developers and teams run the app with Docker more easily.
